### PR TITLE
Add ways to reset scissors

### DIFF
--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -45,6 +45,8 @@
            #:clear-buffers
            #:reset-viewport
            #:apply-scissors
+           #:reset-scissors
+           #:with-scissors
            #:draw-line
            #:draw-curve
            #:draw-rect

--- a/src/path.lisp
+++ b/src/path.lisp
@@ -59,6 +59,18 @@
                 (f w) (f h)))
 
 
+(defun reset-scissors ()
+  (%nanovg:reset-scissor *canvas-handle*))
+
+
+(defmacro with-scissors (origin w h &body body)
+  `(unwind-protect
+        (progn
+          (scissors ,origin ,w ,h)
+          ,@body)
+     (reset-scissors)))
+
+
 (defun line-cap ()
   (error "Only setter available"))
 


### PR DESCRIPTION
example usage:
```
(ge.vg:scissors (ge.ng:vec2 10f0 10f0) 100f0 100f0)
(ge.vg:draw-rect (ge.ng:vec2 10f0 10f0) 500f0 500f0 :fill-paint (ge.ng:vec4 1f0 0f0 0f0 1f0))
(ge.vg:reset-scissors) ; new function

(ge.vg:with-scissors (ge.ng:vec2 50f0 50f0) 100f0 100f0 ; new macro
        (ge.vg:draw-rect (ge.ng:vec2 30f0 30f0) 500f0 500f0 :fill-paint (ge.ng:vec4 1f0 1f0 0f0 1f0)))
```