### PR TITLE
ppc64: Refer to %nanovg:|C:@S@NV-GCOLOR@UA@SA| structure directly

### DIFF
--- a/src/canvas.lisp
+++ b/src/canvas.lisp
@@ -130,7 +130,7 @@
 
 
 (defun stroke-color (color)
-  (c-with ((color-v %nanovg:color))
+  (c-with ((color-v %nanovg:|C:@S@NV-GCOLOR@UA@SA|))
     (setf (color-v :r) (x color)
           (color-v :g) (y color)
           (color-v :b) (z color)
@@ -139,7 +139,7 @@
 
 
 (defun fill-color (color)
-  (c-with ((color-v %nanovg:color))
+  (c-with ((color-v %nanovg:|C:@S@NV-GCOLOR@UA@SA|))
     (setf (color-v :r) (x color)
           (color-v :g) (y color)
           (color-v :b) (z color)


### PR DESCRIPTION
I'm filing this for discussion purposes; it shouldn't be merged.  I have to debug why this is necessary on ppc64 and ppc64le in order to avoid:

```
CL-USER> (ql:quickload :trivial-gamekit)
To load "trivial-gamekit":
  Load 1 ASDF system:
    trivial-gamekit
; Loading "trivial-gamekit"
.

; file: /build/quicklisp/local-projects/bodge-canvas/src/canvas.lisp
; in: DEFUN STROKE-COLOR
;     (SETF (BODGE-CANVAS::COLOR-V :R) (BODGE-MATH:X BODGE-CANVAS::COLOR)
;           (BODGE-CANVAS::COLOR-V :G) (BODGE-MATH:Y BODGE-CANVAS::COLOR)
;           (BODGE-CANVAS::COLOR-V :B) (BODGE-MATH:Z BODGE-CANVAS::COLOR)
;           (BODGE-CANVAS::COLOR-V :A) (BODGE-MATH:W BODGE-CANVAS::COLOR))
; ==>
;   (SETF (BODGE-CANVAS::COLOR-V :R) (BODGE-MATH:X BODGE-CANVAS::COLOR))
; 
; caught ERROR:
;   during macroexpansion of (SETF # #). Use *BREAK-ON-SIGNALS* to intercept.
;   
;    Slot with name R not found. Available names: @0

; ==>
;   (SETF (BODGE-CANVAS::COLOR-V :G) (BODGE-MATH:Y BODGE-CANVAS::COLOR))
; 
; caught ERROR:
;   during macroexpansion of (SETF # #). Use *BREAK-ON-SIGNALS* to intercept.
;   
;    Slot with name G not found. Available names: @0

; ==>
;   (SETF (BODGE-CANVAS::COLOR-V :B) (BODGE-MATH:Z BODGE-CANVAS::COLOR))
; 
; caught ERROR:
;   during macroexpansion of (SETF # #). Use *BREAK-ON-SIGNALS* to intercept.
;   
;    Slot with name B not found. Available names: @0

; ==>
;   (SETF (BODGE-CANVAS::COLOR-V :A) (BODGE-MATH:W BODGE-CANVAS::COLOR))
; 
; caught ERROR:
;   during macroexpansion of (SETF # #). Use *BREAK-ON-SIGNALS* to intercept.
;   
;    Slot with name A not found. Available names: @0

; in: DEFUN FILL-COLOR
;     (SETF (BODGE-CANVAS::COLOR-V :R) (BODGE-MATH:X BODGE-CANVAS::COLOR)
;           (BODGE-CANVAS::COLOR-V :G) (BODGE-MATH:Y BODGE-CANVAS::COLOR)
;           (BODGE-CANVAS::COLOR-V :B) (BODGE-MATH:Z BODGE-CANVAS::COLOR)
;           (BODGE-CANVAS::COLOR-V :A) (BODGE-MATH:W BODGE-CANVAS::COLOR))
; ==>
;   (SETF (BODGE-CANVAS::COLOR-V :R) (BODGE-MATH:X BODGE-CANVAS::COLOR))
; 
; caught ERROR:
;   during macroexpansion of (SETF # #). Use *BREAK-ON-SIGNALS* to intercept.
;   
;    Slot with name R not found. Available names: @0

; ==>
;   (SETF (BODGE-CANVAS::COLOR-V :G) (BODGE-MATH:Y BODGE-CANVAS::COLOR))
; 
; caught ERROR:
;   during macroexpansion of (SETF # #). Use *BREAK-ON-SIGNALS* to intercept.
;   
;    Slot with name G not found. Available names: @0

; ==>
;   (SETF (BODGE-CANVAS::COLOR-V :B) (BODGE-MATH:Z BODGE-CANVAS::COLOR))
; 
; caught ERROR:
;   during macroexpansion of (SETF # #). Use *BREAK-ON-SIGNALS* to intercept.
;   
;    Slot with name B not found. Available names: @0

; ==>
;   (SETF (BODGE-CANVAS::COLOR-V :A) (BODGE-MATH:W BODGE-CANVAS::COLOR))
; 
; caught ERROR:
;   during macroexpansion of (SETF # #). Use *BREAK-ON-SIGNALS* to intercept.
;   
;    Slot with name A not found. Available names: @0
.
; 
; compilation unit aborted
;   caught 1 fatal ERROR condition
;   caught 8 ERROR conditions
; Evaluation aborted on #<UIOP/LISP-BUILD:COMPILE-FILE-ERROR {100E6C300C}>.
```